### PR TITLE
商品購入機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,3 +90,7 @@ gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
 
 gem 'active_hash'
+
+gem 'payjp'
+
+gem 'gon'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,6 +100,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.12.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -111,6 +113,14 @@ GEM
     ffi (1.15.5)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -139,10 +149,14 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.5.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2023.0808)
     mini_magick (4.12.0)
     mini_mime (1.1.5)
     minitest (5.20.0)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     mysql2 (0.5.5)
     net-imap (0.3.7)
       date
@@ -153,6 +167,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.9)
     nokogiri (1.15.4-x86_64-linux)
       racc (~> 1.4)
@@ -161,6 +176,8 @@ GEM
     parser (3.2.2.3)
       ast (~> 2.4.1)
       racc
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.5.4)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -211,9 +228,16 @@ GEM
     regexp_parser (2.8.1)
     reline (0.3.8)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.6)
     rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
@@ -272,6 +296,9 @@ GEM
       railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -303,11 +330,13 @@ DEPENDENCIES
   devise
   factory_bot_rails
   faker
+  gon
   image_processing (~> 1.2)
   importmap-rails
   jbuilder
   mini_magick
   mysql2 (~> 0.5)
+  payjp
   pg
   pry-rails
   puma (~> 5.0)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,7 +23,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
-    unless user_signed_in? && current_user.id == @item.user_id
+    if @item.order.present?
+      redirect_to action: :index
+    elsif user_signed_in? && current_user.id == @item.user_id
+      set_item
+    elsif user_signed_in? && current_user.id != @item.user_id
       redirect_to action: :index
     end
   end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,44 @@
+class OrdersController < ApplicationController
+  before_action :set_item, only: [:index, :create]
+
+  def index
+    if user_signed_in? == false || current_user.id == @item.user_id 
+      redirect_to root_path
+    elsif @item.order.present?
+      redirect_to root_path
+    else
+      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+      @order_destination = OrderDestination.new
+    end
+  end
+
+  def create
+    @order_destination = OrderDestination.new(destination_params)
+    if @order_destination.valid?
+      pay_item
+      @order_destination.save
+      redirect_to root_path
+    else
+      gon.public_key = ENV["PAYJP_PUBLIC_KEY"]
+      render :index, status: :unprocessable_entity
+    end
+  end
+
+  private
+  def set_item
+    @item = Item.find(params[:item_id])
+  end
+
+  def destination_params
+    params.require(:order_destination).permit(:postal_code, :prefecture_id, :city, :addresses, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+  end
+
+  def pay_item
+    Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+    Payjp::Charge.create(
+      amount: @item.price,
+      card: destination_params[:token],
+      currency: 'jpy'
+    )
+  end
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -2,3 +2,4 @@
 import "@hotwired/turbo-rails"
 import "controllers"
 import "item_price"
+import "card"

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,32 @@
+const pay = () => {
+  const publicKey = gon.public_key
+  const payjp = Payjp(publicKey)
+  const elements = payjp.elements();
+  const numberElement = elements.create('cardNumber');
+  const expiryElement = elements.create('cardExpiry');
+  const cvcElement = elements.create('cardCvc');
+
+  numberElement.mount('#number-form');
+  expiryElement.mount('#expiry-form');
+  cvcElement.mount('#cvc-form');
+  const form = document.getElementById('charge-form')
+  form.addEventListener("submit", (e) => {
+    payjp.createToken(numberElement).then(function (response) {
+      if (response.error) {
+      } else {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden">`;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+      numberElement.clear();
+      expiryElement.clear();
+      cvcElement.clear();
+      document.getElementById("charge-form").submit();
+    });
+    e.preventDefault();
+  });
+};
+
+window.addEventListener("load", pay);
+window.addEventListener("turbo:render", pay);

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,0 +1,3 @@
+class Destination < ApplicationRecord
+  belongs_to :order
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,7 +9,7 @@ class Item < ApplicationRecord
   belongs_to :user
   has_one_attached :image
   # has_many :comments
-  # has_one :order
+  has_one :order
 
   # 商品画像必須
   validates :image, presence: true

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,5 @@
+class Order < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+  has_one :destination
+end

--- a/app/models/order_destination.rb
+++ b/app/models/order_destination.rb
@@ -1,0 +1,26 @@
+class OrderDestination
+  include ActiveModel::Model
+  attr_accessor :user_id, :item_id, :postal_code, :prefecture_id, :city, :addresses, :building, :phone_number, :order_id, :token
+
+  with_options presence: true do
+    validates :token
+    validates :user_id
+    validates :item_id
+    validates :city
+    validates :addresses
+    # 郵便番号は半角数字3桁、ハイフン、半角数字4桁の組み合わせでないと保存できない
+    validates :postal_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Enter it as follows (e.g. 123-4567)"}
+    # 電話番号は半角数字しか保存できない
+    validates :phone_number, format: {with: /\A[0-9]+\z/, message: "is invalid. Input only number."}
+    # 電話番号は10文字以上11文字以下でないと保存できない
+    validates :phone_number, length: {in: 10..11, message: "is too short"}
+  end
+
+  # 都道府県は「---」の時は保存できない
+  validates :prefecture_id, numericality: {other_than: 1, message: "can't be blank"}
+
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Destination.create(postal_code: postal_code, prefecture_id: prefecture_id, city: city, addresses: addresses, building: building, phone_number: phone_number, order_id: order.id)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
 
   has_many :items
-  # has_many :orders
+  has_many :orders
   # has_many :comments
 
   validates :nickname, presence: true

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -134,11 +134,11 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
-          <%# <div class='sold-out'> %>
-            <%# <span>Sold Out!!</span> %>
-          <%# </div> %>
-          <%# //商品が売れていればsold outを表示しましょう %>
+      <% if item.order.present? %>
+        <div class='sold-out'>
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
 
         </div>
         <div class='item-info'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,13 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <%# <div class="sold-out"> %>
-        <%# <span>Sold Out!!</span> %>
-      <%# </div> %>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+
+      <% if @item.order.present? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <% end %>
+
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,14 +25,16 @@
       </span>
     </div>
 
-  <% if user_signed_in? && current_user.id == @item.user_id %>
+  <% if @item.order.present? %>
+  <% elsif user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", edit_item_path(@item.id), data: { turbo: false }, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
   <% end %>
   
-  <% if user_signed_in? && current_user.id != @item.user_id %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+  <% if @item.order.present? %>
+  <% elsif user_signed_in? && current_user.id != @item.user_id %>
+    <%= link_to "購入画面に進む", item_orders_path(@item.id) , data: { turbo: false }, class:"item-red-btn"%>
   <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -30,9 +30,6 @@
     <%= link_to "商品の編集", edit_item_path(@item.id), data: { turbo: false }, method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
-  <% end %>
-  
-  <% if @item.order.present? %>
   <% elsif user_signed_in? && current_user.id != @item.user_id %>
     <%= link_to "購入画面に進む", item_orders_path(@item.id) , data: { turbo: false }, class:"item-red-btn"%>
   <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
+  <script type="text/javascript" src="https://js.pay.jp/v2/pay.js"></script>
   <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   <%= javascript_importmap_tags %>
 </head>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,130 @@
+<%= include_gon %>
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag @item.image, class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= @item.name %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.shipping_fee_status.name %></p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= @item.price %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+
+    <%= form_with model: @order_destination, url: item_orders_path(@item), id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+
+    <%= render 'shared/error_messages', model: @order_destination %>
+
+    <%# カード情報の入力 %>
+    <div class='credit-card-form'>
+      <h1 class='info-input-haedline'>
+        クレジットカード情報入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">カード情報</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="number-form" class="input-default"></div>
+        <div class='available-card'>
+          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">有効期限</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div class='input-expiration-date-wrap'>
+          <div id="expiry-form" class="input-default"></div>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">セキュリティコード</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div id="cvc-form" class="input-default"></div>
+      </div>
+    </div>
+    <%# /カード情報の入力 %>
+    
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :postal_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {selected: 1}, {class:"select-box", id:"prefecture"}) %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :addresses, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+      </div>
+    </div>
+    <%# /配送先の入力 %>
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,data: { turbo: false }, class:"buy-red-btn", id:"button" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -6,3 +6,4 @@ pin "@hotwired/stimulus", to: "stimulus.min.js", preload: true
 pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: true
 pin_all_from "app/javascript/controllers", under: "controllers"
 pin "item_price", to: "item_price.js"
+pin "card", to: "card.js"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,8 @@ Rails.application.routes.draw do
   get 'items/index'
   root to: "items#index"
   resources :items
+
+  resources :items do
+    resources :orders, only: [:index, :create]
+  end
 end

--- a/db/migrate/20230923090452_create_orders.rb
+++ b/db/migrate/20230923090452_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[7.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230923105153_create_destinations.rb
+++ b/db/migrate/20230923105153_create_destinations.rb
@@ -1,0 +1,14 @@
+class CreateDestinations < ActiveRecord::Migration[7.0]
+  def change
+    create_table :destinations do |t|
+      t.string     :postal_code,    null: false
+      t.integer    :prefecture_id,  null: false
+      t.string     :city,           null: false
+      t.string     :addresses,      null: false
+      t.string     :building
+      t.string     :phone_number,   null: false
+      t.references :order,          null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_09_16_075134) do
+ActiveRecord::Schema[7.0].define(version: 2023_09_23_105153) do
   create_table "active_storage_attachments", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -44,6 +44,19 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_16_075134) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "destinations", charset: "utf8", force: :cascade do |t|
+    t.string "postal_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "addresses", null: false
+    t.string "building"
+    t.string "phone_number", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["order_id"], name: "index_destinations_on_order_id"
+  end
+
   create_table "items", charset: "utf8", force: :cascade do |t|
     t.string "name", null: false
     t.text "info", null: false
@@ -57,6 +70,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_16_075134) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", charset: "utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "prefectures", charset: "utf8", force: :cascade do |t|
@@ -99,5 +121,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_16_075134) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "destinations", "orders"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/spec/factories/destinations.rb
+++ b/spec/factories/destinations.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :destination do
+
+  end
+end

--- a/spec/factories/order_destinations.rb
+++ b/spec/factories/order_destinations.rb
@@ -7,8 +7,5 @@ FactoryBot.define do
     addresses { '1-1' }
     building { '東京ハイツ' }
     phone_number { '09012345678' }
-
-    association :user_id
-    association :item_id
   end
 end

--- a/spec/factories/order_destinations.rb
+++ b/spec/factories/order_destinations.rb
@@ -1,0 +1,14 @@
+FactoryBot.define do
+  factory :order_destination do
+    token { 'tok_abcdefghijklmnopqrstuvwxyz01' }
+    postal_code { '123-4567' }
+    prefecture_id { 14 }
+    city { '中央区' }
+    addresses { '1-1' }
+    building { '東京ハイツ' }
+    phone_number { '09012345678' }
+
+    association :user_id
+    association :item_id
+  end
+end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :order do
+  end
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Destination, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/order_destination_spec.rb
+++ b/spec/models/order_destination_spec.rb
@@ -1,0 +1,92 @@
+require 'rails_helper'
+
+RSpec.describe OrderDestination, type: :model do
+
+   before do
+     @user = FactoryBot.create(:user)
+     @item = FactoryBot.create(:item)
+     @order_destination = FactoryBot.build(:order_destination,user_id: @user.id, item_id: @item.id)
+   end
+
+  describe '商品購入' do
+    context '商品が購入できる場合' do
+      it '必要事項を全て過不足なく入力すると購入できる' do
+        expect(@order_destination).to be_valid
+      end
+
+      it '建物名のみ空欄でも購入できる' do
+        @order_destination.building = ''
+        expect(@order_destination).to be_valid
+      end
+    end
+
+    context '商品が購入できない場合' do
+      it 'tokenが空だと購入できない' do
+        @order_destination.token = nil
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Token can't be blank")
+      end
+
+      it '郵便番号が空だと購入できない' do
+        @order_destination.postal_code = ''
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Postal code can't be blank")
+      end
+
+      it '郵便番号にハイフンが含まれていないと購入できない' do
+        @order_destination.postal_code = '1234567'
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Postal code is invalid. Enter it as follows (e.g. 123-4567)")
+      end
+
+      it '都道府県が「---」では購入できない' do
+        @order_destination.prefecture_id = '1'
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Prefecture can't be blank")
+      end
+
+      it '市区町村が空だと購入できない' do
+        @order_destination.city = ''
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("City can't be blank")
+      end
+
+      it '番地が空だと購入できない' do
+        @order_destination.addresses = ''
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Addresses can't be blank")
+      end
+
+      it '電話番号が空だと購入できない' do
+        @order_destination.phone_number = nil
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Phone number can't be blank")
+      end
+
+      it '電話番号に半角数字以外が含まれていると購入できない' do
+        @order_destination.phone_number = '０１２３４５６７ああ'
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Phone number is invalid. Input only number.")
+      end
+
+      it '電話番号が10桁未満だと購入できない' do
+        @order_destination.phone_number = '090123456'
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Phone number is too short")
+      end
+
+      it 'user_idが紐づいていなければ購入できない' do
+        @order_destination.user_id = ''
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("User can't be blank")
+      end
+
+      it 'item_idが紐づいていなければ購入できない' do
+        @order_destination.item_id = ''
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Item can't be blank")
+      end
+    end
+    
+  end
+end

--- a/spec/models/order_destination_spec.rb
+++ b/spec/models/order_destination_spec.rb
@@ -75,6 +75,12 @@ RSpec.describe OrderDestination, type: :model do
         expect(@order_destination.errors.full_messages).to include("Phone number is too short")
       end
 
+      it '電話番号が12桁以上だと購入できない' do
+        @order_destination.phone_number = '090123456789'
+        @order_destination.valid?
+        expect(@order_destination.errors.full_messages).to include("Phone number is too short")
+      end
+
       it 'user_idが紐づいていなければ購入できない' do
         @order_destination.user_id = ''
         @order_destination.valid?

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/orders_spec.rb
+++ b/spec/requests/orders_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end


### PR DESCRIPTION
# What
商品購入機能の実装

# Why
商品売買はフリマアプリに欠かせないため

# Gyazo
■必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/15847f3a36f4b7836eb2fc2bb0b97f37

■入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/31a97ae4efd0f81cacd1a6dc37baeedd

■ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/391a6f1a61babe430f0e8ac216d8309b

■ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/ca675288dadf6cf077ddbe4150f41764

■ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/7bf6212d19774e209632072a61a204f1

■売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
https://gyazo.com/fc0203a051778459921238eb4cfe8cee

■売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/cf3e6855b7fe8c8144fd49fe7bdb778e

■ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/4b4c907df115b98eaca18d45c22dfe52

■ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/cc91896e6188433bd954b00efe61dbc1

■テスト結果の画像
https://gyazo.com/90df063279d94a0065f56fe5b758ffb0
